### PR TITLE
Remove .git and .gitattributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.git
+nbproject
+.gitattributes
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .git
-nbproject
 .gitattributes
 


### PR DESCRIPTION
.git and .gitattributes are unneeded and not relevant.
Adding entries for them in .gitignore will stop them from being commited in the future.